### PR TITLE
feat: 조직 생성 및 권한별 조직/유저 목록 조회 #2

### DIFF
--- a/src/controllers/organizationController.ts
+++ b/src/controllers/organizationController.ts
@@ -1,0 +1,57 @@
+import type { Request, Response } from "express";
+import { OrganizationService } from "../services/organizationService.js";
+
+const organizationService = new OrganizationService();
+
+export const createOrganization = async (req: Request, res: Response) => {
+  try {
+    // 1. 현재 로그인 유저 정보
+    const currentUser = req.user!;
+
+    // 2. 서비스 로직 호출
+    const newOrganization = await organizationService.registerOrganization(
+      req.body,
+      currentUser
+    );
+
+    res.status(201).json({
+      success: true,
+      message: "회사(조직)가 성공적으로 등록되었습니다.",
+      data: newOrganization,
+    });
+  } catch (error: any) {
+    // 서비스에서 던진 에러 메시지에 따라 상태 코드 분기 가능
+    const status = error.message.includes("권한") ? 403 : 400;
+    res.status(status).json({ message: error.message });
+  }
+};
+
+export const getOrganizations = async (req: Request, res: Response) => {
+  try {
+    const currentUser = req.user!;
+
+    const organizations = await organizationService.getOrganizations(
+      currentUser
+    );
+
+    res.status(200).json({ data: organizations });
+  } catch (error: any) {
+    res.status(400).json({ message: error.message });
+  }
+};
+
+export const getUsersInOrganization = async (req: Request, res: Response) => {
+  try {
+    const currentUser = req.user!;
+    const { orgId } = req.query;
+
+    const users = await organizationService.getUsers(
+      currentUser,
+      orgId as string
+    );
+
+    res.status(200).json({ data: users });
+  } catch (error: any) {
+    res.status(400).json({ message: error.message });
+  }
+};

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -32,7 +32,7 @@ export const approveUser = async (req: Request, res: Response) => {
     if (!userId) {
       return res.status(400).json({ message: "승인할 유저 ID가 필요합니다." });
     }
-    const result = await userService.approveManager(userId, req.user!);
+    const result = await userService.approveStatusChange(userId, req.user!);
     res.status(200).json({ message: "승인 완료", data: result });
   } catch (error: any) {
     res.status(400).json({ message: error.message });

--- a/src/repositories/organizationRepository.ts
+++ b/src/repositories/organizationRepository.ts
@@ -3,12 +3,14 @@ import { Role } from "@prisma/client";
 import type { CreateUserDto } from "../types/user.js";
 
 export class OrganizationRepository {
-  async create(name: string) {
+  // 조직 생성
+  async createOrganization(name: string) {
     return prisma.organization.create({
       data: { name },
     });
   }
 
+  // 조직 생성 및 유저 생성 : 회사조직부터 사용자 정보까지 전부 입력하는 케이스 (보류)
   async createWithUser(orgName: string, userData: CreateUserDto) {
     return prisma.$transaction(async (tx) => {
       // 1. 조직 먼저 생성
@@ -31,7 +33,8 @@ export class OrganizationRepository {
     });
   }
 
-  async findAll() {
+  // 조직 목록 조회
+  async findAllOrganizations() {
     return prisma.organization.findMany({
       orderBy: { createdAt: "desc" },
     });

--- a/src/repositories/userRepository.ts
+++ b/src/repositories/userRepository.ts
@@ -68,6 +68,7 @@ export class UserRepository {
     });
   }
 
+  // 특정 조직의 유저 조회
   async findByOrganization(organizationId: string) {
     return prisma.user.findMany({
       where: { organizationId },
@@ -75,6 +76,19 @@ export class UserRepository {
     });
   }
 
+  // 전체 유저 조회 (SUPER_ADMIN용)
+  async findAllUsers() {
+    return prisma.user.findMany({
+      include: {
+        organization: {
+          select: { name: true }, // 어느 회사 소속인지 표시
+        },
+      },
+      orderBy: { createdAt: "desc" },
+    });
+  }
+
+  // 사용자 (계정)상태 변경
   async updateStatus(userId: string, status: UserStatus) {
     return prisma.user.update({
       where: { id: userId },

--- a/src/routes/organizationRoutes.ts
+++ b/src/routes/organizationRoutes.ts
@@ -1,0 +1,23 @@
+import { Router } from "express";
+import {
+  createOrganization,
+  getOrganizations,
+  getUsersInOrganization,
+} from "../controllers/organizationController.js";
+import { authenticateToken } from "../middlewares/authMiddleware.js";
+
+const router = Router();
+
+// 모든 조직 관련 API 미들웨어 적용
+router.use(authenticateToken);
+
+// 조직 생성 (POST /api/organizations)
+router.post("/", createOrganization);
+
+// 조직 목록 조회 (GET /api/organizations)
+router.get("/", getOrganizations);
+
+// 조직 내 유저 목록 조회 (GET /api/organizations/users)
+router.get("/users", getUsersInOrganization);
+
+export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import cors from "cors";
 import authRoutes from "./routes/authRoutes.js";
 import userRoutes from "./routes/userRoutes.js";
 import invitationRoutes from "./routes/invitationRoutes.js";
+import organizationRoutes from "./routes/organizationRoutes.js";
 // swagger 관련
 import swaggerUi from "swagger-ui-express";
 import { specs } from "./config/swagger.js";
@@ -23,12 +24,13 @@ app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(specs));
 
 // 기본 헬스체크 라우트
 app.get("/", (req: Request, res: Response) => {
-  res.send("Chat Service Backend is Running~~~");
+  res.send("DadaChat Service Backend is Running~~~");
 });
 
 app.use("/api/auth", authRoutes);
 app.use("/api/users", userRoutes);
 app.use("/api/invitations", invitationRoutes);
+app.use("/api/organizations", organizationRoutes);
 
 // 서버 시작
 app.listen(PORT, () => {

--- a/src/services/organizationService.ts
+++ b/src/services/organizationService.ts
@@ -1,0 +1,41 @@
+import { OrganizationRepository } from "../repositories/organizationRepository.js";
+import { UserRepository } from "../repositories/userRepository.js";
+
+export class OrganizationService {
+  private organizationRepository = new OrganizationRepository();
+  private userRepository = new UserRepository();
+
+  // 조직 생성
+  async registerOrganization(data: { name: string }, user: { role: string }) {
+    if (user.role !== "ADMIN") {
+      throw new Error("접근 권한이 없습니다.");
+    }
+    return await this.organizationRepository.createOrganization(data.name);
+  }
+
+  // 조직 목록 조회
+  async getOrganizations(user: { role: string }) {
+    if (user.role !== "ADMIN") {
+      throw new Error("접근 권한이 없습니다.");
+    }
+
+    return await this.organizationRepository.findAllOrganizations();
+  }
+
+  // 조직 소속 유저 목록 조회
+  async getUsers(
+    user: { role: string; organizationId: string },
+    targetOrgId?: string
+  ) {
+    // ADMIN인 경우, 모든 유저 조회
+    if (user.role === "ADMIN") {
+      if (targetOrgId) {
+        return await this.userRepository.findByOrganization(targetOrgId);
+      }
+      return await this.userRepository.findAllUsers();
+    }
+
+    // 그 외, 해당 조직 유저들만 조회
+    return await this.userRepository.findByOrganization(user.organizationId);
+  }
+}

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -42,7 +42,7 @@ export class UserService {
     });
   }
 
-  async approveManager(
+  async approveStatusChange(
     targetUserId: string,
     agentUser: { organizationId: string; role: Role }
   ) {
@@ -79,5 +79,16 @@ export class UserService {
         throw new Error("유효하지 않거나 이미 사용된 초대장입니다.");
       }
     });
+  }
+
+  // 유저 목록 조회
+  async getUsers(user: { role: string; organizationId: string }) {
+    // ADMIN인 경우, 모든 유저
+    if (user.role === "ADMIN") {
+      return await this.userRepository.findAllUsers();
+    }
+
+    // 그 외, 해당 조직 유저들만 반환
+    return await this.userRepository.findByOrganization(user.organizationId);
   }
 }

--- a/test.http
+++ b/test.http
@@ -85,3 +85,25 @@ Content-Type: application/json
   "name": "장초대",
   "organizationId": "2e132fcd-bfb5-4eb2-b12c-c80568fc042e"
 }
+
+### 조직 생성
+POST http://localhost:4000/api/organizations
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIzMzYxYjFkZi1jMmRiLTRjODItYjJkZC1lODRkZjFlODEyODAiLCJyb2xlIjoiQURNSU4iLCJvcmdhbml6YXRpb25JZCI6IjJlMTMyZmNkLWJmYjUtNGViMi1iMTJjLWM4MDU2OGZjMDQyZSIsImlhdCI6MTc2NjgwNzE0NCwiZXhwIjoxNzY2ODEwNzQ0fQ.O0bInzeFBCjhg3lzA_hMF4YHg1C5jBivQGDWNnJHp2o
+Content-Type: application/json
+
+{
+  "name": "다다로그" // 62b9effc-04e4-424c-a070-177e715e6684
+}
+
+### 조직 목록 조회 시도 (어드민)
+GET http://localhost:4000/api/organizations
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIzMzYxYjFkZi1jMmRiLTRjODItYjJkZC1lODRkZjFlODEyODAiLCJyb2xlIjoiQURNSU4iLCJvcmdhbml6YXRpb25JZCI6IjJlMTMyZmNkLWJmYjUtNGViMi1iMTJjLWM4MDU2OGZjMDQyZSIsImlhdCI6MTc2NjgwNzUxNywiZXhwIjoxNzY2ODExMTE3fQ.teCf5pBOkipCatxYmPDpAJuKzH8bBa9c4x99A1bMG6M
+
+### 특정 조직의 유저 조회(어드민)
+GET http://localhost:4000/api/organizations/users?orgId=62b9effc-04e4-424c-a070-177e715e6684
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIzMzYxYjFkZi1jMmRiLTRjODItYjJkZC1lODRkZjFlODEyODAiLCJyb2xlIjoiQURNSU4iLCJvcmdhbml6YXRpb25JZCI6IjJlMTMyZmNkLWJmYjUtNGViMi1iMTJjLWM4MDU2OGZjMDQyZSIsImlhdCI6MTc2NjgwNzUxNywiZXhwIjoxNzY2ODExMTE3fQ.teCf5pBOkipCatxYmPDpAJuKzH8bBa9c4x99A1bMG6M
+
+
+### 유저 목록 조회
+GET http://localhost:4000/api/organizations/users
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIwOTM5N2FmNy1iZDZjLTQ3NGEtYWZlMS1mOGE5NmUwNzY1N2MiLCJyb2xlIjoiQUdFTlQiLCJvcmdhbml6YXRpb25JZCI6IjYxNTgxMTRhLTE3ZmUtNDZmYy04NDU2LWZmYzU3ZWFkNDVlYiIsImlhdCI6MTc2NjgwNzQyMCwiZXhwIjoxNzY2ODExMDIwfQ.NUsrZNtkRy-wYQTYtH0ciNT-KPTSW8C8g1DC0oEtkqY


### PR DESCRIPTION
이슈 번호 : #2 

작업 요약 : 조직 생성 및 조직 목록 조회, 조직 소속의 유저 조회 api 구현/ 테스트

### 작업내역
- [X] 기존에 작업한 organizationRepository에 연결할 레포지토리/컨트롤러/라우트 구현
- [X] 어드민 권한에서의 조직 소속 목록 조회 api 추가 구현